### PR TITLE
WIP: added ZODB session interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,12 @@ A simple example uses the in-memory session interface.
 ```python
     from sanic import Sanic
     from sanic.response import text
-    from sanic_session import InMemorySessionInterface
+    import sanic_session
 
 
     app = Sanic()
-    session_interface = InMemorySessionInterface()
+    sanic_session.install_middleware(app, 'InMemorySessionInterface')
 
-    @app.middleware('request')
-    async def add_session_to_request(request):
-        # before each request initialize a session
-        # using the client's request
-        await session_interface.open(request)
-
-
-    @app.middleware('response')
-    async def save_session(request, response):
-        # after each request save the session,
-        # pass the response to set client cookies
-        await session_interface.save(request, response)
 
     @app.route("/")
     async def index(request):

--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -1,6 +1,7 @@
 from .memcache_session_interface import MemcacheSessionInterface
 from .redis_session_interface import RedisSessionInterface
 from .in_memory_session_interface import InMemorySessionInterface
+from .zodb_session_interface import ZODBSessionInterface
 
 # Delay exceptions for missing mongodb dependencies to allow us to
 # work as long as mongodb is not being used.
@@ -21,6 +22,7 @@ def install_middleware(app, interface):
         InMemorySessionInterface, RedisSessionInterface,
         MemcacheSessionInterface, MongoDBSessionInterface
     """
+    global session_interface
     if interface == 'InMemorySessionInterface':
         session_interface = InMemorySessionInterface()
     elif interface == 'MemcacheSessionInterface':
@@ -29,6 +31,8 @@ def install_middleware(app, interface):
         session_interface = RedisSessionInterface()
     elif interface == 'MongoDBSessionInterface':
         session_interface = MongoDBSessionInterface()
+    elif interface == 'ZODBSessionInterface':
+        session_interface = ZODBSessionInterface()
 
     @app.middleware('request')
     async def add_session_to_request(request):

--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -11,3 +11,34 @@ except ModuleNotFoundError as e:
     class MongoDBSessionInterface(object):
         def __init__(self, *args, **kwargs):
             raise saved_exception
+
+
+def install_middleware(app, interface):
+    """Installs middleware to application, which will be launched every request.
+    'app' - sanic 'Application' instance to add middleware.
+    'interface' - name of interface to use.
+    Can be:
+        InMemorySessionInterface, RedisSessionInterface,
+        MemcacheSessionInterface, MongoDBSessionInterface
+    """
+    if interface == 'InMemorySessionInterface':
+        session_interface = InMemorySessionInterface()
+    elif interface == 'MemcacheSessionInterface':
+        session_interface = MemcacheSessionInterface()
+    elif interface == 'RedisSessionInterface':
+        session_interface = RedisSessionInterface()
+    elif interface == 'MongoDBSessionInterface':
+        session_interface = MongoDBSessionInterface()
+
+    @app.middleware('request')
+    async def add_session_to_request(request):
+        """Before each request initialize a session using the client's request.
+        """
+        await session_interface.open(request)
+
+    @app.middleware('response')
+    async def save_session(request, response):
+        """After each request save the session,
+        pass the response to set client cookies.
+        """
+        await session_interface.save(request, response)

--- a/sanic_session/zodb_session_interface.py
+++ b/sanic_session/zodb_session_interface.py
@@ -1,0 +1,159 @@
+"""
+ZODB allows different storages for different tasks:
+    - FileStorage for storing data on disk,
+    - In-memory storage for storing data into RAM,
+    - ClientStorage for accesing ZODB server by URL,
+        can be used as database in production,
+        also as in-memory store in production.
+TODO:
+    implement it.
+    - add async function-worker, who'll clean all expired sessions
+        one per several minutes.
+        It must only work when Sanic doesn't handle any request.
+      Or store по очереди в список времи истечения, каждый запрос проверяем первый,
+        скорость возростет
+"""
+
+import ujson
+from sanic_session.base import BaseSessionInterface, SessionDict, _calculate_expires
+from sanic_session.utils import ExpiringDict
+import uuid
+
+
+class ZODBSessionInterface(BaseSessionInterface):
+    def __init__(self,
+                 zodb_connection,
+                 domain: str=None,
+                 expiry: int = 2592000,
+                 httponly: bool=True,
+                 cookie_name: str = 'session',
+                 prefix: str='session:',
+                 sessioncookie: bool=False
+                ):
+
+        self.expiry = expiry
+        self.prefix = 'sanic_session'
+        self.cookie_name = cookie_name
+        self.domain = domain
+        self.httponly = httponly
+        self.sessioncookie = sessioncookie
+        self.zodb_connection = zodb_connection
+        self.zodb_root = zodb_connection.root()
+
+        import BTrees.OOBTree
+        import transaction
+        from persistent import Persistent
+
+        self.zodb_root[self.prefix] = BTrees.OOBTree.BTree()
+        self.zodb_transaction = transaction
+
+        class PersistentSessionDict(Persistent):
+            """Session dict, which is also subclass of ZODB Persistant class,
+            which allows saving all data using "transaction.commit()".
+            Note, that when changing changeable (lists, dicts) attributes
+            of Persistent class,
+            than you have to manually set "_p_changed" attribute to true
+            for object to be saved on "transaction.commit()".
+            """
+            def __init__(self, sid=None):
+                self.session_dict = {}
+                self.sid = sid
+                self.expiration = expiry
+
+            def __setattr__(self, *args, **kwargs):
+                super().__setattr__(*args, **kwargs)
+
+            def __delattr__(self, *args, **kwargs):
+                super().__delattr__(*args, **kwargs)
+                self._p_changed = True
+
+            def __setitem__(self, *args, **kwargs):
+                super().__setitem__(*args, **kwargs)
+                self._p_changed = True
+
+            def __delitem__(self, *args, **kwargs):
+                super().__delitem__(*args, **kwargs)
+                self._p_changed = True
+
+            def __getitem__(self, *args, **kwargs):
+                return self.session_dict.__getitem__(*args, **kwargs)
+
+            def keys(self, *args, **kwargs):
+                return self.session_dict.keys(*args, **kwargs)
+
+            sid = None
+            expiration = None
+            session_dict = None
+
+        self.PersistentSessionDict = PersistentSessionDict
+
+    async def open(self, request):
+        """Opens an ZODB session onto the request. Restores the client's session
+        from memory if one exists.The session will be available on
+        `request.session`.
+
+
+        Args:
+            request (sanic.request.Request):
+                The request, which a session will be opened onto.
+
+        Returns:
+            dict:
+                the client's session data,
+                attached as well to `request.session`.
+        """
+        sid = request.cookies.get(self.cookie_name)
+
+        if not sid:
+            sid = uuid.uuid4().hex
+            persistent_session_dict = self.PersistentSessionDict(sid=sid)
+            self.zodb_root[self.prefix][sid] = persistent_session_dict
+        else:
+            try:
+                persistent_session_dict = self.zodb_root[self.prefix][sid]
+            except KeyError:
+                persistent_session_dict = self.PersistentSessionDict(sid=sid)
+                self.zodb_root[self.prefix][sid] = persistent_session_dict
+
+        request['session'] = persistent_session_dict
+        return persistent_session_dict
+
+    async def save(self, request, response) -> None:
+        """Saves the session to the ZODB session store.
+
+        Args:
+            request (sanic.request.Request):
+                The sanic request which has an attached session.
+            response (sanic.response.Response):
+                The Sanic response. Cookies with the appropriate expiration
+                will be added onto this response.
+
+        Returns:
+            None
+        """
+        if 'session' not in request:
+            return
+
+        sid = request['session'].sid
+        if not request['session'].keys():
+            if sid in self.zodb_root[self.prefix]:
+                del self.zodb_root[self.prefix][sid]
+                self.zodb_root._p_changed = True
+                self.zodb_transaction.commit()
+            if request['session']._p_changed:
+                self._delete_cookie(request, response)
+            return
+
+        if request['session']._p_changed:
+            self.zodb_root[self.prefix][sid].expires = _calculate_expires(self.expiry)
+            self.zodb_transaction.commit()
+
+        self._set_cookie_expiration(request, response)
+        # BEFORE finishing must run removing old stuff from database
+
+    def get_session(self, sid):
+        try:
+            val = self.zodb_root[self.prefix][sid]
+        except KeyError:
+            val = None
+        return val

--- a/tests/test_zodb_session_interface.py
+++ b/tests/test_zodb_session_interface.py
@@ -1,0 +1,93 @@
+import time
+from sanic.response import text
+from ..zodb_session_interface import ZODBSessionInterface  # change to sanic_session.zodb_session_interface
+# on production
+import pytest
+import uuid
+import ujson
+
+
+SID = '5235262626'
+COOKIE_NAME = 'cookie'
+COOKIES = {COOKIE_NAME: SID}
+
+
+@pytest.fixture
+def mock_dict():
+    class MockDict(dict):
+        pass
+
+    return MockDict
+
+
+def get_zodb_conn():
+    import ZODB, ZODB.FileStorage
+
+    database_im = ZODB.DB(None)
+    db_im_connection = database_im.open()
+    db_im_root = db_im_connection.root()
+
+    return db_im_connection
+
+
+@pytest.mark.asyncio
+async def test_should_create_new_sid_if_no_cookie(mocker, mock_dict):
+    request = mock_dict()
+    request.cookies = {}
+
+    mocker.spy(uuid, 'uuid4')
+    session_interface = ZODBSessionInterface(get_zodb_conn())
+    await session_interface.open(request)
+
+    assert uuid.uuid4.call_count == 1, 'should create a new SID with uuid'
+    assert request['session'].keys() == {}.keys(), 'should return an empty dict as session'
+
+"""
+@pytest.mark.asyncio
+async def test_should_return_data_from_session_store(mocker, mock_dict):
+    request = mock_dict()
+
+    request.cookies = COOKIES
+
+    mocker.spy(uuid, 'uuid4')
+    data = {'foo': 'bar'}
+
+    session_interface = ZODBSessionInterface(*get_zodb_conn(),
+        cookie_name=COOKIE_NAME)
+    session_interface.session_store.get = mocker.MagicMock(
+        return_value=ujson.dumps(data))
+
+    session = await session_interface.open(request)
+
+    assert uuid.uuid4.call_count == 0, 'should not create a new SID'
+    assert session_interface.session_store.get.call_count == 1, \
+        'should call on redis once'
+
+    assert session_interface.session_store.get.call_args_list[0][0][0] == \
+        'session:{}'.format(SID), 'should get from store with prefix + SID'
+
+    assert session.get('foo') == 'bar', 'session data is pulled from store'
+
+
+@pytest.mark.asyncio
+async def test_should_use_prefix_in_store_key(mocker, mock_dict):
+    request = mock_dict()
+    prefix = 'differentprefix:'
+    data = {'foo': 'bar'}
+
+    request.cookies = COOKIES
+
+    session_interface = ZODBSessionInterface(*get_zodb_conn(),
+        cookie_name=COOKIE_NAME,
+        prefix=prefix)
+    session_interface.session_store.get = mocker.MagicMock(
+        return_value=ujson.dumps(data))
+    await session_interface.open(request)
+
+    assert session_interface.session_store.get.call_args_list[0][0][0] == \
+        '{}{}'.format(prefix, SID), 'should call redis with prefix + SID'
+
+
+
+
+"""


### PR DESCRIPTION
ZODB can work with different information storing backends, including file backend, relational database backend, in-memory backend, so it could be used as session storage for Sanic.

TODO:
- Make connections to ZODB non-blocking using `loop.run_in_executor`.
- Add support for removing objects after their lifetime expires (for example, make some worker coroutine for this.