### PR TITLE
Fixed bug with session inside session.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ session = Session(app, interface=InMemorySessionInterface())
 @app.route("/")
 async def index(request):
     # interact with the session like a normal dict
-    if not request.ctx.session['session'].get('foo'):
-        request.ctx.session['session']['foo'] = 0
+    if not request.ctx.session.get('foo'):
+        request.ctx.session['foo'] = 0
 
-    request.ctx.session['session']['foo'] += 1
+    request.ctx.session['foo'] += 1
 
-    return text(request.ctx.session['session']['foo'])
+    return text(request.ctx.session['foo'])
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -21,8 +21,8 @@ When initializing a session interface, you have a number of optional arguments f
     One of 'strict' or 'lax'. Defaults to None  https://www.owasp.org/index.php/SameSite
 **session_name** (str, optional):
     | Name of the session that will be accessible through the request.
-    | e.g. If ``session_name`` is ``alt_session``, it should be accessed like that: ``request.ctx.session['alt_session']``
-    | e.g. And if ``session_name`` is left to default, it should be accessed like that: ``request.ctx.session['session']``
+    | e.g. If ``session_name`` is ``alt_session``, it should be accessed like that: ``request.ctx.alt_session``
+    | e.g. And if ``session_name`` is left to default, it should be accessed like that: ``request.ctx.session``
 
     .. note::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,12 +41,12 @@ A simple example uses the in-memory session interface.
     @app.route("/")
     async def index(request):
         # interact with the session like a normal dict
-        if not request.ctx.session['session'].get('foo'):
-            request.ctx.session['session']['foo'] = 0
+        if not request.ctx.session.get('foo'):
+            request.ctx.session['foo'] = 0
 
-        request.ctx.session['session']['foo'] += 1
+        request.ctx.session['foo'] += 1
 
-        return text(request.ctx.session['session']['foo'])
+        return text(request.ctx.session['foo'])
 
     if __name__ == "__main__":
         app.run(host="0.0.0.0", port=8000, debug=True)

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -46,12 +46,12 @@ When building your application you'll eventually want to test that your sessions
 
     @app.route("/")
     async def index(request):
-        if not request.ctx.session['session'].get('foo'):
-            request.ctx.session['session']['foo'] = 0
+        if not request.ctx.session.get('foo'):
+            request.ctx.session['foo'] = 0
 
-        request.ctx.session['session']['foo'] += 1
+        request.ctx.session['foo'] += 1
 
-        response = text(request.ctx.session['session']['foo'])
+        response = text(request.ctx.session['foo'])
 
         return response
 

--- a/docs/source/using_the_interfaces.rst
+++ b/docs/source/using_the_interfaces.rst
@@ -58,12 +58,12 @@ To integrate Redis with :code:`sanic_session` you need to pass a getter method i
     @app.route("/")
     async def test(request):
         # interact with the session like a normal dict
-        if not request.ctx.session['session'].get('foo'):
-            request.ctx.session['session']['foo'] = 0
+        if not request.ctx.session.get('foo'):
+            request.ctx.session['foo'] = 0
 
-        request.ctx.session['session']['foo'] += 1
+        request.ctx.session['foo'] += 1
 
-        response = text(request.ctx.session['session']['foo'])
+        response = text(request.ctx.session['foo'])
 
         return response
 
@@ -101,12 +101,12 @@ This example shows little different approach. You can use classic Flask extensio
     @app.route("/")
     async def test(request):
         # interact with the session like a normal dict
-        if not request.ctx.session['session'].get('foo'):
-            request.ctx.session['session']['foo'] = 0
+        if not request.ctx.session.get('foo'):
+            request.ctx.session['foo'] = 0
 
-        request.ctx.session['session']['foo'] += 1
+        request.ctx.session['foo'] += 1
 
-        response = text(request.ctx.session['session']['foo'])
+        response = text(request.ctx.session['foo'])
 
         return response
 
@@ -146,12 +146,12 @@ To integrate memcache with :code:`sanic_session` you need to pass an :code:`aiom
     @app.route("/")
     async def test(request):
         # interact with the session like a normal dict
-        if not request.ctx.session['session'].get('foo'):
-            request.ctx.session['session']['foo'] = 0
+        if not request.ctx.session.get('foo'):
+            request.ctx.session['foo'] = 0
 
-        request.ctx.session['session']['foo'] += 1
+        request.ctx.session['foo'] += 1
 
-        response = text(request.ctx.session['session']['foo'])
+        response = text(request.ctx.session['foo'])
 
         return response
 
@@ -181,12 +181,12 @@ In-Memory
     @app.route("/")
     async def index(request):
         # interact with the session like a normal dict
-        if not request.ctx.session['session'].get('foo'):
-            request.ctx.session['session']['foo'] = 0
+        if not request.ctx.session.get('foo'):
+            request.ctx.session['foo'] = 0
 
-        request.ctx.session['session']['foo'] += 1
+        request.ctx.session['foo'] += 1
 
-        return text(request.ctx.session['session']['foo'])
+        return text(request.ctx.session['foo'])
 
     if __name__ == "__main__":
         app.run(host="0.0.0.0", port=8000, debug=True)

--- a/example/example.py
+++ b/example/example.py
@@ -9,12 +9,12 @@ session = Session(app, interface=InMemorySessionInterface())
 @app.route("/")
 async def index(request):
     # interact with the session like a normal dict
-    if not request.ctx.session["session"].get("foo"):
-        request.ctx.session["session"]["foo"] = 0
+    if not request.ctx.session.get("foo"):
+        request.ctx.session["foo"] = 0
 
-    request.ctx.session["session"]["foo"] += 1
+    request.ctx.session["foo"] += 1
 
-    return text(request.ctx.session["session"]["foo"])
+    return text(request.ctx.session["foo"])
 
 
 if __name__ == "__main__":

--- a/sanic_session/aioredis.py
+++ b/sanic_session/aioredis.py
@@ -48,9 +48,9 @@ class AIORedisSessionInterface(BaseSessionInterface):
             session_name (str, optional):
                 Name of the session that will be accessible through the request.
                 e.g. If ``session_name`` is ``alt_session``, it should be
-                accessed like that: ``request.ctx.session['alt_session']``
+                accessed like that: ``request.ctx.alt_session``
                 e.g. And if ``session_name`` is left to default, it should be
-                accessed like that: ``request.ctx.session['session']``
+                accessed like that: ``request.ctx.session``
                 Default: 'session'
             secure (bool, optional):
                 Adds the `Secure` flag to the session cookie.

--- a/sanic_session/memcache.py
+++ b/sanic_session/memcache.py
@@ -52,9 +52,9 @@ class MemcacheSessionInterface(BaseSessionInterface):
                 Name of the session that will be accessible through the
                 request.
                 e.g. If ``session_name`` is ``alt_session``, it should be
-                accessed like that: ``request.ctx.session['alt_session']``
+                accessed like that: ``request.ctx.alt_session``
                 e.g. And if ``session_name`` is left to default, it should be
-                accessed like that: ``request.ctx.session['session']``
+                accessed like that: ``request.ctx.session``
                 Default: 'session'
             secure (bool, optional):
                 Adds the `Secure` flag to the session cookie.

--- a/sanic_session/mongodb.py
+++ b/sanic_session/mongodb.py
@@ -67,9 +67,9 @@ class MongoDBSessionInterface(BaseSessionInterface):
                 Name of the session that will be accessible through the
                 request.
                 e.g. If ``session_name`` is ``alt_session``, it should be
-                accessed like that: ``request.ctx.session['alt_session']``
+                accessed like that: ``request.ctx.alt_session``
                 e.g. And if ``session_name`` is left to default, it should be
-                accessed like that: ``request.ctx.session['session']``
+                accessed like that: ``request.ctx.session``
                 Default: 'session'
             secure (bool, optional):
                 Adds the `Secure` flag to the session cookie.

--- a/sanic_session/redis.py
+++ b/sanic_session/redis.py
@@ -52,9 +52,9 @@ class RedisSessionInterface(BaseSessionInterface):
                 Name of the session that will be accessible through the
                 request.
                 e.g. If ``session_name`` is ``alt_session``, it should be
-                accessed like that: ``request.ctx.session['alt_session']``
+                accessed like that: ``request.ctx.alt_session``
                 e.g. And if ``session_name`` is left to default, it should be
-                accessed like that: ``request.ctx.session['session']``
+                accessed like that: ``request.ctx.session``
                 Default: 'session'
             secure (bool, optional):
                 Adds the `Secure` flag to the session cookie.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
 
 setup(
     name="sanic_session",
-    version="0.7.0",
+    version="0.7.1",
     description=(
         "Provides server-backed sessions for Sanic " "using Redis, Memcache and more."
     ),

--- a/tests/test_memcache_session_interface.py
+++ b/tests/test_memcache_session_interface.py
@@ -65,7 +65,7 @@ async def test_memcache_should_create_new_sid_if_no_cookie(mocker, mock_memcache
     await session_interface.open(request)
 
     assert uuid.uuid4.call_count == 1, "should create a new SID with uuid"
-    assert request.ctx.session["session"] == {}, "should return an empty dict as session"
+    assert request.ctx.session == {}, "should return an empty dict as session"
 
 
 @pytest.mark.asyncio
@@ -136,7 +136,7 @@ async def test_should_attach_session_to_request(mock_memcache, mock_dict):
     session_interface = MemcacheSessionInterface(memcache_connection, cookie_name=COOKIE_NAME)
     session = await session_interface.open(request)
 
-    assert session == request.ctx.session["session"]
+    assert session == request.ctx.session
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_should_expire_memcache_cookies_if_modified(mock_dict, mock_memcac
 
     await session_interface.open(request)
 
-    request.ctx.session["session"].clear()
+    request.ctx.session.clear()
     await session_interface.save(request, response)
     assert response.cookies[COOKIE_NAME]["max-age"] == 0
     assert response.cookies[COOKIE_NAME]["expires"] < datetime.datetime.utcnow()
@@ -193,11 +193,11 @@ async def test_should_save_in_memcache_for_time_specified(mock_dict, mock_memcac
 
     await session_interface.open(request)
 
-    request.ctx.session["session"]["foo"] = "baz"
+    request.ctx.session["foo"] = "baz"
     await session_interface.save(request, response)
 
     memcache_connection.set.assert_called_with(
-        "session:{}".format(SID).encode(), ujson.dumps(request.ctx.session["session"]).encode(), exptime=2592000
+        "session:{}".format(SID).encode(), ujson.dumps(request.ctx.session).encode(), exptime=2592000
     )
 
 
@@ -215,7 +215,7 @@ async def test_should_reset_cookie_expiry(mocker, mock_dict, mock_memcache):
     session_interface = MemcacheSessionInterface(memcache_connection, cookie_name=COOKIE_NAME)
 
     await session_interface.open(request)
-    request.ctx.session["session"]["foo"] = "baz"
+    request.ctx.session["foo"] = "baz"
     await session_interface.save(request, response)
 
     assert response.cookies[COOKIE_NAME].value == SID
@@ -256,7 +256,7 @@ async def test_sessioncookie_delete_has_expiration_headers(mocker, mock_dict, mo
 
     await session_interface.open(request)
     await session_interface.save(request, response)
-    request.ctx.session["session"].clear()
+    request.ctx.session.clear()
     await session_interface.save(request, response)
 
     assert response.cookies[COOKIE_NAME]["max-age"] == 0


### PR DESCRIPTION
During refactoring for Sanic 20.3.0 a mistake was made,
SessionDict had a key session where actual session was stored
There was no session key before refactoring and it's not needed