### PR TITLE
Add Sanic Extension support

### DIFF
--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -1,9 +1,9 @@
 from .aioredis import AIORedisSessionInterface
+from .extension import Session
 from .memcache import MemcacheSessionInterface
 from .memory import InMemorySessionInterface
 from .mongodb import MongoDBSessionInterface
 from .redis import RedisSessionInterface
-from .extension import Session
 
 __all__ = (
     "MemcacheSessionInterface",

--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -3,6 +3,7 @@ from .memcache import MemcacheSessionInterface
 from .memory import InMemorySessionInterface
 from .mongodb import MongoDBSessionInterface
 from .redis import RedisSessionInterface
+from .extension import Session
 
 __all__ = (
     "MemcacheSessionInterface",
@@ -12,35 +13,3 @@ __all__ = (
     "AIORedisSessionInterface",
     "Session",
 )
-
-
-class Session:
-    def __init__(self, app=None, interface=None):
-        self.interface = None
-        if app:
-            self.init_app(app, interface)
-
-    def init_app(self, app, interface):
-        self.interface = interface or InMemorySessionInterface()
-        if not hasattr(app.ctx, "extensions"):
-            app.ctx.extensions = {}
-
-        app.ctx.extensions[
-            self.interface.session_name
-        ] = self  # session_name defaults to 'session'
-
-        # @app.middleware('request')
-        async def add_session_to_request(request):
-            """Before each request initialize a session
-            using the client's request."""
-            await self.interface.open(request)
-
-        # @app.middleware('response')
-        async def save_session(request, response):
-            """After each request save the session, pass
-            the response to set client cookies.
-            """
-            await self.interface.save(request, response)
-
-        app.request_middleware.appendleft(add_session_to_request)
-        app.response_middleware.append(save_session)

--- a/sanic_session/extension.py
+++ b/sanic_session/extension.py
@@ -1,0 +1,49 @@
+from .memory import InMemorySessionInterface
+
+try:
+    from sanic_ext import Extension
+
+    SANIC_EXTENSIONS = True
+except ImportError:
+    Extension = type("Extension", (), {})  # type: ignore
+    SANIC_EXTENSIONS = False
+
+
+class Session(Extension):
+    name = "session"
+
+    def __init__(self, app=None, interface=None):
+        self.interface = interface
+        if app:
+            self.init_app(app, interface)
+
+    def init_app(self, app, interface):
+        self.interface = interface or InMemorySessionInterface()
+        if not hasattr(app.ctx, "extensions"):
+            app.ctx.extensions = {}
+
+        app.ctx.extensions[
+            self.interface.session_name
+        ] = self  # session_name defaults to 'session'
+
+        async def add_session_to_request(request):
+            """Before each request initialize a session
+            using the client's request."""
+            await self.interface.open(request)
+
+        async def save_session(request, response):
+            """After each request save the session, pass
+            the response to set client cookies.
+            """
+            await self.interface.save(request, response)
+
+        app.request_middleware.appendleft(add_session_to_request)
+        app.response_middleware.append(save_session)
+
+    def startup(self, _) -> None:
+        if not SANIC_EXTENSIONS:
+            raise RuntimeError("Sanic Extensions is not installed")
+        self.init_app(self.app, self.interface)
+
+    def label(self):
+        return self.interface.__class__.__name__


### PR DESCRIPTION
Adds support for integration with Sanic Extensions:


```python
Extend.register(Session)
```

```python
class Redis:
    ...


redis = Redis()
Extend.register(Session(interface=RedisSessionInterface(redis.get_redis_pool)))
```