### PR TITLE
Default to no cookie refresh

### DIFF
--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -1,8 +1,11 @@
+from typing import Optional
 from .aioredis import AIORedisSessionInterface
 from .memcache import MemcacheSessionInterface
 from .memory import InMemorySessionInterface
 from .mongodb import MongoDBSessionInterface
 from .redis import RedisSessionInterface
+from sanic import Sanic
+from .base import BaseSessionInterface
 
 __all__ = (
     "MemcacheSessionInterface",
@@ -15,13 +18,23 @@ __all__ = (
 
 
 class Session:
-    def __init__(self, app=None, interface=None):
-        self.interface = None
+    def __init__(
+        self,
+        app: Optional[Sanic] = None,
+        interface: Optional[BaseSessionInterface] = None,
+        renew_cookie: bool = False,
+    ):
+        self.interface = interface
+        self.renew_cookie = renew_cookie
         if app:
             self.init_app(app, interface)
 
-    def init_app(self, app, interface):
+    def init_app(
+        self, app: Sanic, interface: Optional[BaseSessionInterface] = None
+    ):
         self.interface = interface or InMemorySessionInterface()
+        self.interface.renew_cookie = self.renew_cookie
+
         if not hasattr(app.ctx, "extensions"):
             app.ctx.extensions = {}
 

--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 from .aioredis import AIORedisSessionInterface
 from .memcache import MemcacheSessionInterface
 from .memory import InMemorySessionInterface
@@ -6,6 +6,7 @@ from .mongodb import MongoDBSessionInterface
 from .redis import RedisSessionInterface
 from sanic import Sanic
 from .base import BaseSessionInterface
+from .policy import RenewalPolicy
 
 __all__ = (
     "MemcacheSessionInterface",
@@ -22,10 +23,14 @@ class Session:
         self,
         app: Optional[Sanic] = None,
         interface: Optional[BaseSessionInterface] = None,
-        renew_cookie: bool = False,
+        renew_cookie: Union[str, RenewalPolicy] = RenewalPolicy.NEVER,
     ):
         self.interface = interface
-        self.renew_cookie = renew_cookie
+        self.renew_cookie = (
+            renew_cookie
+            if isinstance(renew_cookie, RenewalPolicy)
+            else RenewalPolicy[renew_cookie.upper()]
+        )
         if app:
             self.init_app(app, interface)
 

--- a/sanic_session/__init__.py
+++ b/sanic_session/__init__.py
@@ -1,12 +1,14 @@
 from typing import Optional, Union
+
+from sanic import Sanic
+
 from .aioredis import AIORedisSessionInterface
+from .base import BaseSessionInterface
 from .memcache import MemcacheSessionInterface
 from .memory import InMemorySessionInterface
 from .mongodb import MongoDBSessionInterface
-from .redis import RedisSessionInterface
-from sanic import Sanic
-from .base import BaseSessionInterface
 from .policy import RenewalPolicy
+from .redis import RedisSessionInterface
 
 __all__ = (
     "MemcacheSessionInterface",

--- a/sanic_session/base.py
+++ b/sanic_session/base.py
@@ -47,6 +47,7 @@ class BaseSessionInterface(metaclass=abc.ABCMeta):
         self.samesite = samesite
         self.session_name = session_name
         self.secure = secure
+        self.renew_cookie = False
 
     def _delete_cookie(self, request, response):
         req = get_request_container(request)
@@ -65,6 +66,12 @@ class BaseSessionInterface(metaclass=abc.ABCMeta):
 
     def _set_cookie_props(self, request, response):
         req = get_request_container(request)
+        if (
+            not self.renew_cookie
+            and request.cookies.get(self.cookie_name)
+            == req[self.session_name].sid
+        ):
+            return  # session_id same with client, do nothing
         response.cookies[self.cookie_name] = req[self.session_name].sid
         response.cookies[self.cookie_name]["httponly"] = self.httponly
 

--- a/sanic_session/base.py
+++ b/sanic_session/base.py
@@ -2,6 +2,7 @@ import abc
 import datetime
 import time
 import uuid
+from sanic_session.policy import RenewalPolicy
 
 import ujson
 
@@ -47,7 +48,7 @@ class BaseSessionInterface(metaclass=abc.ABCMeta):
         self.samesite = samesite
         self.session_name = session_name
         self.secure = secure
-        self.renew_cookie = False
+        self.renew_cookie: RenewalPolicy = RenewalPolicy.NEVER
 
     def _delete_cookie(self, request, response):
         req = get_request_container(request)
@@ -67,7 +68,7 @@ class BaseSessionInterface(metaclass=abc.ABCMeta):
     def _set_cookie_props(self, request, response):
         req = get_request_container(request)
         if (
-            not self.renew_cookie
+            self.renew_cookie is not RenewalPolicy.ALWAYS
             and request.cookies.get(self.cookie_name)
             == req[self.session_name].sid
         ):

--- a/sanic_session/base.py
+++ b/sanic_session/base.py
@@ -2,10 +2,10 @@ import abc
 import datetime
 import time
 import uuid
-from sanic_session.policy import RenewalPolicy
 
 import ujson
 
+from sanic_session.policy import RenewalPolicy
 from sanic_session.utils import CallbackDict
 
 


### PR DESCRIPTION
Closes #85 

@yurenchen000

This PR implements your change. However, it also adds a renewal policy so that:

1. it is possible to retain the existing behavior
2. there is flexibility for adding different types of renewals as you mentioned in #85 in the future