### PR TITLE
Added support for redis as a new replacement for aioredis

### DIFF
--- a/sanic_session/aioredis.py
+++ b/sanic_session/aioredis.py
@@ -1,9 +1,13 @@
 from sanic_session.base import BaseSessionInterface
 
 try:
-    import aioredis
+    # redis was merged with aioredis https://github.com/redis/redis-py/releases/tag/v4.2.0rc1
+    from redis import asyncio as aioredis
 except ImportError:
-    aioredis = None
+    try:
+        import aioredis
+    except ImportError:
+        aioredis = None
 
 
 class AIORedisSessionInterface(BaseSessionInterface):

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Fix for #95
aioredis was merged into redis https://github.com/redis/redis-py/releases/tag/v4.2.0rc1